### PR TITLE
static-favicon depreciated. updated dependencies to serve-favicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "dependencies": {
         "express": "~4.0.0",
-        "static-favicon": "~1.0.0",
+        "serve-favicon": "*",
         "morgan": "~1.0.0",
         "cookie-parser": "~1.0.1",
         "body-parser": "~1.0.0",


### PR DESCRIPTION
The static-favicon has been depreciated and causes error on on npm start. I suggest changing to the new module serve-favicon.

The only change needed I noticed on your tutorial is to update the snippet code for the package.json.
http://cwbuecheler.com/web/tutorials/2014/restful-web-app-node-express-mongodb/

Reason for change:
running npm install: npm WARN deprecated static-favicon@2.0.0-alpha: use serve-favicon module
